### PR TITLE
Add tab-completion for bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # cdc [directory]
 I have a few directories in which I clone repositories. This function will
-change directory to the passed argument, no matter which directory it's in,
-complete with tab-completion for its arguments for `zsh` users. Any help getting
-this implemented in `bash` would be appreciated.
+change directory to the passed argument, no matter which of the
+repository-containing directories it's in. Comes with tab-completion for its
+arguments, as long as your `zsh`/`bash` version supports it.
 
+## Rationale
 I chose to make this function rather than editing `$CDPATH` because I don't like
 changing the default behavior of `cd`, but you could just as easily do the
 following:
-
 ```sh
 # Assuming `other_repo` exists in `/path/to/repo_dir`
 CDPATH=/path/to/repo_dir
@@ -16,11 +16,6 @@ cd other_repo # will cd to /path/to/repo_dir/other_repo
 ```
 
 ## Installation
-I wrote this function as an
-[oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) plugin, but it will work
-with vanilla `zsh`, or even [bash-it](https://github.com/Bash-it/bash-it)
-or vanilla `bash` (with the exception of tab-completion).
-
 ### oh-my-zsh
 Clone the repository in your `$ZSH_CUSTOM/plugins` directory
 ```sh
@@ -40,13 +35,23 @@ Files in this directory that end with `.bash` are automatically sourced, so
 there's nothing else to do.
 
 ### Vanilla zsh or bash
-Just source either the `cdc.plugin.zsh` file for `zsh`, or `cdc.plugin.bash`
-file for `bash`, from one of your startup files, such as `~/.zshrc` or
-`~/.bashrc`.
+Clone the repository wherever you like, and source either the `cdc.plugin.zsh`
+file for `zsh`, or `cdc.plugin.bash` file for `bash`, from one of your startup
+files, such as `~/.zshrc` or `~/.bashrc`, respectively.
 
-If you're using `zsh`, and auto-completion doesn't work, please add your
-pertinent config info (such as shell framework, operation system, etc.) to [this
-issue](https://github.com/evanthegrayt/cdc/issues/4) in a comment.
+```sh
+# Where $INSTALLATION_PATH is the path to where you installed the plugin.
+source $INSTALLATION_PATH/cdc.plugin.zsh  # in ~/.zshrc
+source $INSTALLATION_PATH/cdc.plugin.bash # in ~/.bashrc
+```
+
+If you're using a version of `zsh`/`bash` that doesn't support the completion
+features, or you just don't want to use them, just source the `cdc.sh` file
+directly.
+
+```sh
+source $INSTALLATION_PATH/cdc.sh # in either ~/.zshrc or ~/.bashrc
+```
 
 ## Set-up
 To use this feature, you need to set `CDC_DIRS` in either a startup file (such
@@ -55,7 +60,7 @@ absolute paths to the directories to search.
 
 ```sh
 # Set this in either `~/.zshrc` (or similar), or in `~/.cdcrc`
-CDC_DIRS=($HOME/dir_with_repos $HOME/workspace/repos)
+CDC_DIRS=($HOME/dir_with_repos $HOME/workspace/another_dir_with_repos)
 ```
 
 If you have directories within `CDC_DIRS` that you want the plugin to ignore,
@@ -76,19 +81,16 @@ on the fly; nothing is hard-coded. Hit `return` after typing the directory name
 to change to that directory.
 
 You *can* append subdirectories, and it will work; however, I don't have
-tab-autocompletion working for this yet. For example:
+tab-autocompletion working for this yet (any help with that would be
+appreciated). For example:
 ```sh
-# Assuming the following:
-CDC_DIRS=($HOME/dir_with_repos)
-
-# and `dir_with_repos` has a subdirectory called `bin`, you can:
 cdc dir_with_repos/bin
 ```
 If the subdirectory doesn't exist, it will `cd` to the base directory, and then
 print a message to `stderr`.
 
 ## Reporting bugs
-This program is under development, so if you have an idea or find a bug, please
-[create an issue](https://github.com/evanthegrayt/cdc/issues/new). Just make
-sure the topic doesn't already exist.
+If you have an idea or find a bug, please [create an
+issue](https://github.com/evanthegrayt/cdc/issues/new). Just make sure the topic
+doesn't already exist.
 

--- a/cdc.plugin.bash
+++ b/cdc.plugin.bash
@@ -1,68 +1,10 @@
-# `cd` to my repos in my repo directories. I decided to do this, rather than
-# adding to $CDPATH, because I don't like changing the default `cd` behavior.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/cdc.sh
+
 if [[ -n $BASH_IT ]]; then
     cite about-plugin
     about-plugin 'easily `cd` to common repos from anywhere'
 fi
 
-cdc() {
-
-    [[ -z $REPO_DIRS && -f $HOME/.cdcrc ]] && source "$HOME/.cdcrc"
-
-    local dir
-    local wdir
-    local cd_dir="${1%%/*}"
-    local USAGE="cdc: [DIRECTORY]"
-
-    [[ "$1" == */* ]] && local subdir="${1#*/}"
-
-    if (( ${#CDC_DIRS[@]} == 0 )); then
-        echo "You must either \`export CDC_DIRS=()\` as an environmental" >&2
-        echo "variable, or create a ~/.cdcrc file declaring the array!" >&2
-        return 2
-    elif (( $# != 1 )); then
-        echo $USAGE >&2
-        return 1
-    fi
-
-    for dir in ${CDC_DIRS[@]}; do
-        if ! [[ -d $dir ]]; then
-            echo "[$dir] is exported in \$CDC_DIRS but is not a directory" >&2
-            continue
-        fi
-
-        ([[ ! -d $dir/$cd_dir ]] || _cdc_is_excluded_dir "$cd_dir") && continue
-
-        wdir="$dir/$cd_dir"
-
-        if [[ -n $subdir ]]; then
-            if [[ -d $wdir/$subdir ]]; then
-                wdir+="/$subdir"
-            else
-                echo "[$subdir] does not exist in [$cd_dir]." >&2
-            fi
-        fi
-
-        cd "$wdir"
-
-        return 0
-    done
-
-    echo "[$cd_dir] not found in ${CDC_DIRS[@]}" >&2
-    return 2
-}
-
-_cdc_is_excluded_dir() {
-    local string="$1"
-
-    ([[ -z $CDC_IGNORE ]] || (( ${#CDC_IGNORE[@]} == 0 ))) && return 1
-
-    for element in "${CDC_IGNORE[@]}"; do
-        if [[ "${element/\//}" == "${string/\//}" ]]; then
-            return 0
-        fi
-    done
-
-    return 1
-}
+complete -W "$( _cdc_repo_list )" cdc
 

--- a/cdc.plugin.zsh
+++ b/cdc.plugin.zsh
@@ -1,24 +1,9 @@
-# Source the actual sh function
+source "${0:h}/cdc.sh"
 autoload -U compinit && compinit
-source "${0:h}/cdc.plugin.bash"
-
-_cdc_repo_list() {
-    local dir
-    local subdir
-
-    [[ -z $REPO_DIRS && -f $HOME/.cdcrc ]] && source $HOME/.cdcrc
-
-    for dir in "${CDC_DIRS[@]}"; do
-        cd "$dir"
-        for subdir in */; do
-            if ! _cdc_is_excluded_dir "$subdir"; then
-                echo "$subdir"
-            fi
-        done
-    done
-}
 
 _cdc() {
     _arguments "1: :($( _cdc_repo_list ))"
 }
+
 compdef '_cdc' cdc
+

--- a/cdc.sh
+++ b/cdc.sh
@@ -1,0 +1,77 @@
+cdc() {
+
+    [[ -z $REPO_DIRS && -f $HOME/.cdcrc ]] && source "$HOME/.cdcrc"
+
+    local dir
+    local wdir
+    local cd_dir="${1%%/*}"
+    local USAGE="cdc: [DIRECTORY]"
+
+    [[ "$1" == */* ]] && local subdir="${1#*/}"
+
+    if (( ${#CDC_DIRS[@]} == 0 )); then
+        echo "You must either \`export CDC_DIRS=()\` as an environmental" >&2
+        echo "variable, or create a ~/.cdcrc file declaring the array!" >&2
+        return 2
+    elif (( $# != 1 )); then
+        echo $USAGE >&2
+        return 1
+    fi
+
+    for dir in ${CDC_DIRS[@]}; do
+        if ! [[ -d $dir ]]; then
+            echo "[$dir] is exported in \$CDC_DIRS but is not a directory" >&2
+            continue
+        fi
+
+        ([[ ! -d $dir/$cd_dir ]] || _cdc_is_excluded_dir "$cd_dir") && continue
+
+        wdir="$dir/$cd_dir"
+
+        if [[ -n $subdir ]]; then
+            if [[ -d $wdir/$subdir ]]; then
+                wdir+="/$subdir"
+            else
+                echo "[$subdir] does not exist in [$cd_dir]." >&2
+            fi
+        fi
+
+        cd "$wdir"
+
+        return 0
+    done
+
+    echo "[$cd_dir] not found in ${CDC_DIRS[@]}" >&2
+    return 2
+}
+
+_cdc_is_excluded_dir() {
+    local string="$1"
+
+    ([[ -z $CDC_IGNORE ]] || (( ${#CDC_IGNORE[@]} == 0 ))) && return 1
+
+    for element in "${CDC_IGNORE[@]}"; do
+        if [[ "${element/\//}" == "${string/\//}" ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+_cdc_repo_list() {
+    local dir
+    local subdir
+
+    [[ -z $REPO_DIRS && -f $HOME/.cdcrc ]] && source $HOME/.cdcrc
+
+    for dir in "${CDC_DIRS[@]}"; do
+        cd "$dir"
+        for subdir in */; do
+            if ! _cdc_is_excluded_dir "$subdir"; then
+                echo "$subdir"
+            fi
+        done
+    done
+}
+


### PR DESCRIPTION
- Add tab completion for bash
- Update readme
- Split function into its own file so it can be sourced directly if tab completion isn't supported by the user's shell