### PR TITLE
Options to enable/disable colored output

### DIFF
--- a/cdc.plugin.bash
+++ b/cdc.plugin.bash
@@ -16,5 +16,5 @@ fi
 
 ##
 # Add completion arguments.
-complete -o nospace -W "$( __cdc_repo_list )" cdc
+complete -o nospace -W "$( _cdc_repo_list )" cdc
 

--- a/cdc.plugin.zsh
+++ b/cdc.plugin.zsh
@@ -8,7 +8,7 @@ source "${0:h}/cdc.sh"
 ##
 # Add completion arguments.
 _cdc() {
-    _arguments "1: :($( __cdc_repo_list ))"
+    _arguments "1: :($( _cdc_repo_list ))"
 }
 
 ##


### PR DESCRIPTION
- Adds `-c` and `-C` for enabling/disabling colors
- Renames "private" functions to use one underscore rather than 2
  - This seems to be the convention for most other plugins

Issue #41