### PR TITLE
Add option to re-source config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,10 @@ source $INSTALLATION_PATH/cdc.sh # in either ~/.zshrc or ~/.bashrc
 ```
 
 ## Set-up
-The following settings require variables to be set from either a file called
-`~/.cdcrc`, or a shell startup file such as `~/.zshrc` or `~/.bash_profile`. The
-following instructions will default to using `~/.cdcrc`, but just know that you
-have the other option. Just note, if you are going to put the variables in a
-startup file, set them *after* you source the plugin.
-
-Note that the `~/.cdcrc` file is just a shell script that sets values, so you
-can use `bash` conditionals if you'd like to use the same config file on
-multiple systems. You can view an example of this in [my config
+The following settings require variables to be set from a file called
+`~/.cdcrc`. Note that the `~/.cdcrc` file is just a shell script that sets
+values, so you can use `bash` conditionals if you'd like to use the same config
+file on multiple systems. You can view an example of this in [my config
 file](https://github.com/evanthegrayt/dotfiles/blob/master/dotfiles/cdcrc). Just
 remember, these files get sourced into your interactive shell on startup, so
 only use it to set the following values.
@@ -222,6 +217,7 @@ overriding variables set in `~/.cdcrc`. There's also a debug mode.
 |-U|Do not push the directory onto the stack.|
 |-r|Only `cd` to repositories.|
 |-R|`cd` to the directory even if it's not a repository.|
+|-s|Re-source the config file (`~/.cdcrc`)|
 |-D|Debug mode. Enables warnings for when things aren't working as expected.|
 |-h|Print help.|
 

--- a/cdc.plugin.zsh
+++ b/cdc.plugin.zsh
@@ -19,6 +19,7 @@ _cdc() {
     -d"[List the directories in stack.]" \
     -n"[cd to the current directory in the stack.]" \
     -p"[cd to previous directory and pop from the stack]" \
+    -s"[Re-source the config file ('~/.cdcrc')]" \
     -t"[Toggle between the last two directories in the stack.]" \
     -u"[Push the directory onto the stack.]" \
     -U"[Do not push the directory onto the stack.]" \
@@ -31,4 +32,3 @@ _cdc() {
 ##
 # Define completions.
 compdef '_cdc' cdc
-


### PR DESCRIPTION
- Updated `cdc.sh`
  - Function call now aborts if `~/.cdcrc` is not present. 
    - This no longer allows for settings to be set in a startup file.
    - This was to allow re-sourcing of user's config, which could only be done if it was its own file.
  - Moved "main" part of code to after function definitions so "main" can call the functions if needed.
  - `-s` now re-sources the config file
    - Updated `-h` help menu to include `-s` option
- Updated `README.md` 
  - Include new `-s` option
  - Remove section about being able to set values in startup files, as `~/.cdcrc` is now enforced. 

Issue #34